### PR TITLE
PR-feat/breadcrumb in header

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -29,6 +29,30 @@ const Header = () => {
     else router.push("/");
   }, []);
 
+  const getBreadCrumbs = () => {
+    const crumbs = pathName.split("/").filter(Boolean);
+
+    return crumbs.map((crumb, index) => {
+      const href = "/" + crumbs.slice(0, index + 1).join("/");
+      const label = crumb
+        .replace(/-/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+
+      return (
+        <BreadcrumbItem key={href}>
+          {index === crumbs.length - 1 ? (
+            <BreadcrumbPage>{label}</BreadcrumbPage>
+          ) : (
+            <>
+              <BreadcrumbLink href={href}>{label}</BreadcrumbLink>
+              <BreadcrumbSeparator />
+            </>
+          )}
+        </BreadcrumbItem>
+      );
+    });
+  };
+
   return (
     <header className="flex flex-1 h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 mb-4">
       <div className="flex w-full justify-between items-center gap-2 px-4">
@@ -43,13 +67,11 @@ const Header = () => {
 
             <Breadcrumb className="hidden md:block">
               <BreadcrumbList>
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="#">Dashboard</BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className="hidden md:block" />
                 <BreadcrumbItem>
-                  <BreadcrumbPage>Example</BreadcrumbPage>
+                  <BreadcrumbLink href="/">Home</BreadcrumbLink>
+                  <BreadcrumbSeparator />
                 </BreadcrumbItem>
+                {getBreadCrumbs()}
               </BreadcrumbList>
             </Breadcrumb>
 


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/5b182044-dceb-41f5-acf0-da22dea7c98a" alt="CLR-S (2)"> </p>

# Pull Request | Trustless Work

## 1. Issue Link

<!--https://github.com/Tico4Chain-Coders/dApp-Trustless-Work/issues/58 -->
https://github.com/Tico4Chain-Coders/dApp-Trustless-Work/issues/58

- Closes #(58)

---

## 2. Brief Description of the Issue

<!-- Give a concise description of the issue to give context to reviewers. What problem does it solve? -->
The issue required making the breadcrumb dynamically display the routes actively visited/is on ast at the moment. Also attaching links to it 
---

## 3. Type of Change

Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] 📝 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 👌 Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

---

## 4. Changes Made

<!-- Describe the main changes and enhancements made to address the issue. List the modifications clearly and concisely. -->

- i created a function that got the pathname using usePathName() from next naviagtion, sliced it and mapped through it
- Then i extracted and formulated teh href and teh label that would be displayed
- After that i made the function return the BreadCrumb component having passed in the href and label where necessary

---

## 6. Evidence After Solution

<!-- Record a video using Loom showing the corrected behavior after the solution. Provide a link to the Loom video here. -->
https://www.loom.com/share/8cbe39c30d574cee8c1e2bcdd9226a78?sid=2779d29d-6d53-4976-9f5b-927172215190


---


# If you don't use this template, you'd be ignored
